### PR TITLE
Remove `{}_deploy.jar` implicit target for `java_test`

### DIFF
--- a/with_cfg/private/rule_defaults.bzl
+++ b/with_cfg/private/rule_defaults.bzl
@@ -42,6 +42,5 @@ IMPLICIT_TARGETS = {
     ],
     "java_test": [
         "{}.jar",
-        "{}_deploy.jar",
     ],
 }


### PR DESCRIPTION
This has always been a "misfeature" and removed in https://github.com/bazelbuild/bazel/commit/3ae4e5086061421b05ad3f0083539d8d6cb0fa22.