### PR TITLE
Use `last_rc` for root module builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
             folder: "."
           - os: macos-12
             folder: "."
-          - bazelversion: last_rc
+          - bazelversion: last_green
             folder: "."
 
     steps:
@@ -57,7 +57,7 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'MODULE.bazel') }}
           restore-keys: bazel-cache-
 
       - name: Configure Bazel version


### PR DESCRIPTION
Also add `MODULE.bazel` to the cache key and remove the empty `WORKSPACE`. This should result in more reliable caching for the relatively slow root module (requires compiling protoc).