### PR TITLE
Speed up CI runs with flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,11 @@ common --enable_bzlmod
 # https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0
 common --check_direct_dependencies=off
 
+# Improve build caching by redacting environment variables.
+common --incompatible_strict_action_env
+# Allow build to start before all external deps have been fetched.
+common --experimental_merged_skyframe_analysis_execution
+
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members
 # This needs to be last statement in this

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'MODULE.bazel') }}
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', '**/MODULE.bazel', '**/.bazelrc') }}
           restore-keys: bazel-cache-
 
       - name: Configure Bazel version

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -13,3 +13,8 @@ common --nojava_header_compilation
 # Allow using rules_java 6.5.1 with Bazel 6.4.0rc1.
 # TODO: Remove after the release of Bazel 6.4.0.
 common --check_bazel_compatibility=warning
+
+# Improve build caching by redacting environment variables.
+common --incompatible_strict_action_env
+# Allow build to start before all external deps have been fetched.
+common --experimental_merged_skyframe_analysis_execution


### PR DESCRIPTION
Also include `.bazelrc`s and `MODULE.bazel` files into the cache key.