### PR TITLE
Make implicit output patterns more flexible

### DIFF
--- a/docs/defs.md
+++ b/docs/defs.md
@@ -31,7 +31,7 @@ my_foo_binary, _1 = with_cfg(foo_binary).set(
 | :------------- | :------------- | :------------- |
 | <a id="with_cfg-kind"></a>kind |  The rule (or macro) to use as a base.   |  none |
 | <a id="with_cfg-executable"></a>executable |  Whether the base rule is executable.<br><br>Defaults to `True` if the name of the base rule name ends with `_binary`.   |  `None` |
-| <a id="with_cfg-implicit_targets"></a>implicit_targets |  A list of patterns of implicit targets provided by the base rule.<br><br>Every pattern must contain a single `{}` placeholder for the target name. Not required for rules shipped with Bazel (`cc_*`, `java_*`).   |  `None` |
+| <a id="with_cfg-implicit_targets"></a>implicit_targets |  A list of patterns of implicit targets provided by the base rule.<br><br>A pattern is evaluated with `format` and supplied the following variables: <ul>   <li>`{name}`: The full name of the target (e.g. `subdir/my_target`).   <li>`{basename}`: The basename of the target (e.g. `my_target`).   <li>`{dirprefix}`: The directory prefix of the target (e.g. `subdir/`, usually empty). </ul> Not required for rules shipped with Bazel (`cc_*`, `java_*`).   |  `None` |
 | <a id="with_cfg-extra_providers"></a>extra_providers |  Additional providers to forward from the base rule or macro.   |  `[]` |
 
 **RETURNS**

--- a/examples/java_21_library/BUILD.bazel
+++ b/examples/java_21_library/BUILD.bazel
@@ -16,3 +16,11 @@ java_21_library(
     name = "integer_type",
     srcs = ["src/main/java/com/example/IntegerType.java"],
 )
+
+# This target exists purely to demonstrate (and verify) that implicit outputs of
+# the underlying rule, in this case source jars, are available on the rule
+# produced by with_cfg.
+alias(
+    name = "primes_sources",
+    actual = "libprimes-src.jar",
+)

--- a/with_cfg/private/rule_defaults.bzl
+++ b/with_cfg/private/rule_defaults.bzl
@@ -29,20 +29,22 @@ DEFAULT_PROVIDERS = [
 
 IMPLICIT_TARGETS = {
     "cc_binary": [
-        "{}.dwp",
-        "{}.stripped",
+        "{name}.dwp",
+        "{name}.stripped",
     ],
     "java_binary": [
-        "{}.jar",
-        "{}-src.jar",
-        "{}_deploy.jar",
-        "{}_deploy-src.jar",
+        "{name}.jar",
+        "{name}-src.jar",
+        "{name}_deploy.jar",
+        "{name}_deploy-src.jar",
     ],
     "java_library": [
-        "lib{}.jar",
-        "lib{}-src.jar",
+        # It is not a typo that this uses `{name}` rather than `{basename}`: a java_library with
+        # `name = "dir/foo"` will product a jar at `libdir/foo.jar`, not `dir/libfoo.jar`.
+        "lib{name}.jar",
+        "lib{name}-src.jar",
     ],
     "java_test": [
-        "{}.jar",
+        "{name}.jar",
     ],
 }

--- a/with_cfg/private/with_cfg.bzl
+++ b/with_cfg/private/with_cfg.bzl
@@ -34,7 +34,12 @@ def with_cfg(
         Defaults to `True` if the name of the base rule name ends with `_binary`.
       implicit_targets: A list of patterns of implicit targets provided by the base rule.
 
-        Every pattern must contain a single `{}` placeholder for the target name.
+        A pattern is evaluated with `format` and supplied the following variables:
+        <ul>
+          <li>`{name}`: The full name of the target (e.g. `subdir/my_target`).
+          <li>`{basename}`: The basename of the target (e.g. `my_target`).
+          <li>`{dirprefix}`: The directory prefix of the target (e.g. `subdir/`, usually empty).
+        </ul>
         Not required for rules shipped with Bazel (`cc_*`, `java_*`).
       extra_providers: Additional providers to forward from the base rule or macro.
 
@@ -74,8 +79,12 @@ def with_cfg(
 
     # Validate implicit target patterns eagerly for better error messages.
     for pattern in implicit_targets:
-        if pattern.format(_PATTERN_VALIDATION_MARKER).count(_PATTERN_VALIDATION_MARKER) != 1:
-            fail("Implicit target pattern must contain exactly one '{}' placeholder: " + pattern)
+        if _PATTERN_VALIDATION_MARKER not in pattern.format(
+            name = _PATTERN_VALIDATION_MARKER,
+            basename = _PATTERN_VALIDATION_MARKER,
+            dirprefix = _PATTERN_VALIDATION_MARKER,
+        ):
+            fail("Implicit target pattern must contain {name} or {dirprefix} and {basename}: %s" % pattern)
 
     rule_info = RuleInfo(
         kind = kind,

--- a/with_cfg/private/wrapper.bzl
+++ b/with_cfg/private/wrapper.bzl
@@ -133,16 +133,17 @@ def _wrapper(*, name, kwargs, rule_info, frontend, transitioning_alias, values):
     )
 
     for implicit_target in rule_info.implicit_targets:
-        sub_name = "{dirname}{separator}{sub_basename}".format(
-            dirname = dirname,
-            separator = separator,
-            sub_basename = implicit_target.format(basename),
-        )
-        original_sub_name = "{dirname}{separator}{basename}_/{sub_basename}".format(
-            dirname = dirname,
-            separator = separator,
+        dirprefix = dirname + separator
+        sub_name = implicit_target.format(
+            dirprefix = dirprefix,
             basename = basename,
-            sub_basename = implicit_target.format(basename),
+            name = dirprefix + basename,
+        )
+        original_dirprefix = dirprefix + basename + "_/"
+        original_sub_name = implicit_target.format(
+            dirprefix = original_dirprefix,
+            basename = basename,
+            name = original_dirprefix + basename,
         )
         transitioning_alias(
             name = sub_name,


### PR DESCRIPTION
This is needed since implicit output naming is somewhat broken in Bazel: a `java_library` target with name `dir/foo` results in a `libdir/foo.jar` implicit output, not `dir/libfoo.jar`.