### PR TITLE
Add utility functions for location expression rewriting

### DIFF
--- a/with_cfg/private/rewrite.bzl
+++ b/with_cfg/private/rewrite.bzl
@@ -1,0 +1,104 @@
+load(":select.bzl", "map_attr")
+load(":utils.bzl", "is_dict", "is_list", "is_string")
+
+visibility(["//with_cfg/private/...", "//with_cfg/tests/..."])
+
+# buildifier: disable=unnamed-macro
+def make_label_rewriter(label_map):
+    return lambda label: _label_rewriter_base(label, label_map = label_map)
+
+def _label_rewriter_base(label_string, *, label_map):
+    label = native.package_relative_label(label_string)
+    rewritten_label = label_map.get(label)
+    if not rewritten_label:
+        return label_string
+    return str(rewritten_label)
+
+def rewrite_locations_in_attr(value, label_rewriter):
+    return map_attr(lambda v: _rewrite_locations_in_value(v, label_rewriter), value)
+
+def _rewrite_locations_in_value(value, label_rewriter):
+    if not value:
+        return value
+    if is_dict(value):
+        return {
+            _rewrite_locations_in_single_value(k, label_rewriter): _rewrite_locations_in_list_or_single_value(v, label_rewriter)
+            for k, v in value.items()
+        }
+    return _rewrite_locations_in_list_or_single_value(value, label_rewriter)
+
+def _rewrite_locations_in_list_or_single_value(value, label_rewriter):
+    if not value:
+        return value
+    if is_list(value):
+        return [_rewrite_locations_in_single_value(v, label_rewriter) for v in value]
+    return _rewrite_locations_in_single_value(value, label_rewriter)
+
+# Based on:
+# https://github.com/bazelbuild/bazel/blob/9bf8f396db5c8b204c61b34638ca15ece0328fc0/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl#L777C1-L830C27
+# SPDX: Apache-2.0
+def _rewrite_locations_in_single_value(expression, label_rewriter):
+    if not is_string(expression):
+        return expression
+    if "$(" not in expression:
+        return expression
+
+    idx = 0
+    last_make_var_end = 0
+    result = []
+    n = len(expression)
+    for _ in range(n):
+        if idx >= n:
+            break
+        if expression[idx] != "$":
+            idx += 1
+            continue
+
+        idx += 1
+
+        # We've met $$ pattern, so $ is escaped.
+        if idx < n and expression[idx] == "$":
+            idx += 1
+            result.append(expression[last_make_var_end:idx])
+            last_make_var_end = idx
+            # We might have found a potential start for Make Variable.
+
+        elif idx < n and expression[idx] == "(":
+            # Try to find the closing parentheses.
+            make_var_start = idx
+            make_var_end = make_var_start
+            for j in range(idx + 1, n):
+                if expression[j] == ")":
+                    make_var_end = j
+                    break
+
+            # Note we cannot go out of string's bounds here,
+            # because of this check.
+            # If start of the variable is different from the end,
+            # we found a make variable.
+            if make_var_start != make_var_end:
+                # Some clarifications:
+                # *****$(MAKE_VAR_1)*******$(MAKE_VAR_2)*****
+                #                   ^       ^          ^
+                #                   |       |          |
+                #   last_make_var_end  make_var_start make_var_end
+                result.append(expression[last_make_var_end:make_var_start - 1])
+                make_var = expression[make_var_start + 1:make_var_end]
+                exp = _rewrite_location(make_var, label_rewriter)
+                result.append("$({})".format(exp))
+
+                # Update indexes.
+                idx = make_var_end + 1
+                last_make_var_end = idx
+
+    # Add the last substring which would be skipped by for loop.
+    if last_make_var_end < n:
+        result.append(expression[last_make_var_end:n])
+
+    return "".join(result)
+
+def _rewrite_location(expr, label_rewriter):
+    type, _, label = expr.partition(" ")
+    if not label:
+        return expr
+    return type + " " + label_rewriter(label)

--- a/with_cfg/tests/BUILD.bazel
+++ b/with_cfg/tests/BUILD.bazel
@@ -1,6 +1,9 @@
+load(":rewrite_test.bzl", "rewrite_test_suite")
 load(":rule_test.bzl", "rule_test_suite")
 load(":select_test.bzl", "select_test_suite")
 load(":setting_test.bzl", "setting_test_suite")
+
+rewrite_test_suite(name = "rewrite_test")
 
 rule_test_suite(name = "rule_test")
 

--- a/with_cfg/tests/rewrite_test.bzl
+++ b/with_cfg/tests/rewrite_test.bzl
@@ -1,0 +1,53 @@
+load("@rules_testing//lib:test_suite.bzl", "test_suite")
+load("//with_cfg/private:rewrite.bzl", "rewrite_locations_in_attr")
+
+def _mock_rewriter(label):
+    return label + "_rewritten"
+
+def _rewrite_locations_in_attr_test(env):
+    expect = env.expect
+    rewrite = lambda v: rewrite_locations_in_attr(v, _mock_rewriter)
+
+    expect.that_str(
+        rewrite("@foo//:baz $(location :foo) :bar"),
+    ).equals(
+        "@foo//:baz $(location :foo_rewritten) :bar",
+    )
+    expect.that_str(
+        rewrite("$$$$$(rlocationpath @foo//:baz)$$$(execpath :foo)$$"),
+    ).equals(
+        "$$$$$(rlocationpath @foo//:baz_rewritten)$$$(execpath :foo_rewritten)$$",
+    )
+    expect.that_str(
+        rewrite("$$$$(rlocationpath @foo//:baz)$$$(execpath :foo)$$"),
+    ).equals(
+        "$$$$(rlocationpath @foo//:baz)$$$(execpath :foo_rewritten)$$",
+    )
+    expect.that_str(
+        rewrite("$(JAVA_HOME)"),
+    ).equals(
+        "$(JAVA_HOME)",
+    )
+    expect.that_collection(
+        rewrite(["@foo//:baz", "$(location :foo)", ":bar"]),
+    ).contains_exactly(
+        ["@foo//:baz", "$(location :foo_rewritten)", ":bar"],
+    ).in_order()
+    expect.that_dict(
+        rewrite({"@foo//:baz": "$(rlocationpath :baz)", "bar": "$(location :foo)"}),
+    ).contains_exactly(
+        {"@foo//:baz": "$(rlocationpath :baz_rewritten)", "bar": "$(location :foo_rewritten)"},
+    )
+    expect.that_dict(
+        rewrite({"@foo//:baz": ["$(rlocationpath :baz)", "bar", "$(location :foo)"]}),
+    ).contains_exactly(
+        {"@foo//:baz": ["$(rlocationpath :baz_rewritten)", "bar", "$(location :foo_rewritten)"]},
+    )
+
+def rewrite_test_suite(name):
+    test_suite(
+        name = name,
+        basic_tests = [
+            _rewrite_locations_in_attr_test,
+        ],
+    )


### PR DESCRIPTION
These functions rewrite labels in `$(location ...)`-like attribute values and will be used in a follow-up change to allow the automatic application of the reset target to specified attributes.