### PR TITLE
Add support for coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
         run: echo "${{ matrix.bazelversion }}" > .bazelversion
 
       - name: Install and add ASAN runtime DLL to PATH on Windows
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'windows-2022' && matrix.folder == 'examples'
         run: |
           Start-Process "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" -ArgumentList 'modify --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" --quiet --add Microsoft.VisualStudio.Component.VC.ASAN' -Wait -PassThru
           dir "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC"
@@ -79,4 +79,12 @@ jobs:
           # Bazelisk will download bazel to here.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         working-directory: ${{ matrix.folder }}
-        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} //...
+        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+
+      - name: bazel coverage //...
+        if: matrix.os == 'ubuntu-20.04' && matrix.folder == 'examples'
+        env:
+          # Bazelisk will download bazel to here.
+          XDG_CACHE_HOME: ~/.cache/bazel-repo
+        working-directory: ${{ matrix.folder }}
+        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc --bazelrc=.bazelrc coverage //...

--- a/with_cfg/private/frontend.bzl
+++ b/with_cfg/private/frontend.bzl
@@ -24,7 +24,9 @@ def _frontend_impl(ctx):
     data_runfiles = ctx.runfiles([executable]).merge(target[DefaultInfo].data_runfiles)
     default_runfiles = ctx.runfiles([executable]).merge(target[DefaultInfo].default_runfiles)
 
-    run_environment_info = target[FrontendInfo].run_environment_info or RunEnvironmentInfo(
+    run_environment_info = _clean_run_environment_info(
+        target[FrontendInfo].run_environment_info,
+    ) or RunEnvironmentInfo(
         environment = ctx.attr.env,
         inherited_environment = ctx.attr.env_inherit,
     )
@@ -35,12 +37,35 @@ def _frontend_impl(ctx):
             data_runfiles = data_runfiles,
             default_runfiles = default_runfiles,
         ),
+        coverage_common.instrumented_files_info(
+            ctx = ctx,
+            dependency_attributes = ["exports"],
+        ),
     ] + [
         target[provider]
         for provider in target[FrontendInfo].providers
         if provider in target
     ] + (
         [run_environment_info] if run_environment_info else []
+    )
+
+# Workaround for https://github.com/bazelbuild/bazel/pull/20349:
+# In Bazel 6.4.0, cc_test manually sets LCOV_MERGER to the lcov_merger executable in its own
+# configuration, which is not the configuration of the top-level test wrapping it when that happens
+# through a transition. Remove the variable to let TestActionBuilder set it to the correct value
+# instead.
+# TODO: Remove this workaround eventually.
+def _clean_run_environment_info(run_environment_info):
+    if not run_environment_info or not "LCOV_MERGER" in run_environment_info.environment:
+        return run_environment_info
+    cleaned_environment = {
+        key: value
+        for key, value in run_environment_info.environment.items()
+        if key != "LCOV_MERGER"
+    }
+    return RunEnvironmentInfo(
+        environment = cleaned_environment,
+        inherited_environment = run_environment_info.inherited_environment,
     )
 
 _frontend_attrs = {
@@ -55,8 +80,21 @@ _frontend_attrs = {
     ),
 }
 
+_frontend_test_attrs = {
+    "_lcov_merger": attr.label(
+        default = configuration_field(fragment = "coverage", name = "output_generator"),
+        executable = True,
+        cfg = "exec",
+    ),
+    "_collect_cc_coverage": attr.label(
+        default = "@bazel_tools//tools/test:collect_cc_coverage",
+        executable = True,
+        cfg = "exec",
+    ),
+}
+
 _frontend_executable = rule(_frontend_impl, attrs = _frontend_attrs, executable = True)
-_frontend_test = rule(_frontend_impl, attrs = _frontend_attrs, test = True)
+_frontend_test = rule(_frontend_impl, attrs = _frontend_attrs | _frontend_test_attrs, test = True)
 
 def _frontend_default(*, name, exports, **kwargs):
     native.alias(

--- a/with_cfg/private/rule_defaults.bzl
+++ b/with_cfg/private/rule_defaults.bzl
@@ -7,7 +7,6 @@ DEFAULT_PROVIDERS = [
     CcInfo,
     CcToolchainConfigInfo,
     DebugPackageInfo,
-    InstrumentedFilesInfo,
     JavaInfo,
     JavaPluginInfo,
     OutputGroupInfo,

--- a/with_cfg/private/transitioning_alias.bzl
+++ b/with_cfg/private/transitioning_alias.bzl
@@ -56,6 +56,10 @@ def _transitioning_alias_base_impl(ctx, *, providers):
             data_runfiles = target[DefaultInfo].data_runfiles,
             default_runfiles = target[DefaultInfo].default_runfiles,
         ),
+        coverage_common.instrumented_files_info(
+            ctx = ctx,
+            dependency_attributes = ["exports"],
+        ),
     ]
     if not is_reset_rule:
         returned_providers.append(FrontendInfo(


### PR DESCRIPTION
In addition to the the normal setup consisting of implicit attributes and the use of `coverage_common.instrumented_files_info`, this also requires working around a bug in `cc_test`:
https://github.com/bazelbuild/bazel/pull/20349