### PR TITLE
add example of running same Java test suite on multiple JDK versions

### DIFF
--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -13,6 +13,9 @@ common --incompatible_sandbox_hermetic_tmp
 common --java_language_version=17
 common --java_runtime_version=remotejdk_17
 
+# Use Bazel's embedded JDK for r_j_e's coursier.
+common --repo_env=JAVA_HOME=../../install/embedded_tools/jdk
+
 # Improve build caching by redacting environment variables.
 common --incompatible_strict_action_env
 # On Windows, PATH doubles as the dynamic library search path. We need its

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -7,6 +7,13 @@ default_java_toolchain(
     target_version = "17",
 )
 
+default_java_toolchain(
+    name = "toolchain_jdk_21",
+    java_runtime = "@rules_java//toolchains:remotejdk_21",
+    source_version = "21",
+    target_version = "21",
+)
+
 alias(
     name = "bzl_library",
     actual = "@with_cfg.bzl//:with_cfg",

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -9,8 +9,18 @@ local_path_override(
 bazel_dep(name = "contrib_rules_jvm", version = "0.26.0")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_java", version = "7.3.1")
-bazel_dep(name = "rules_jvm_external", version = "6.1")
+
+# Can't update past this version as it breaks compatibility with Bazel 6 due to
+# the Turbine native image not supporting --release used by rules_jvm_external.
+bazel_dep(name = "rules_java", version = "7.2.0")
+
+# This fork restores compatibility with Bazel 6 and is based on 6.1.
+bazel_dep(name = "rules_jvm_external")
+git_override(
+    module_name = "rules_jvm_external",
+    commit = "0a1704520d2ef8af05613924246a18664a5ed504",
+    remote = "https://github.com/fmeum/rules_jvm_external.git",
+)
 
 register_toolchains(
     "//:toolchain_jdk_17_definition",

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -6,10 +6,25 @@ local_path_override(
     path = "..",
 )
 
+bazel_dep(name = "contrib_rules_jvm", version = "0.26.0")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_java", version = "7.3.1")
+bazel_dep(name = "rules_jvm_external", version = "6.1")
 
 register_toolchains(
     "//:toolchain_jdk_17_definition",
+    "//:toolchain_jdk_21_definition",
 )
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.install(
+    name = "maven_java_test_suite_example",
+    artifacts = [
+        "org.junit.jupiter:junit-jupiter-api:5.10.2",
+        "org.junit.jupiter:junit-jupiter-engine:5.10.2",
+        "org.junit.platform:junit-platform-launcher:1.10.2",
+        "org.junit.platform:junit-platform-reporting:1.10.2",
+    ],
+)
+use_repo(maven, "maven_java_test_suite_example")

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,4 +5,5 @@
 - [cc_define_test](cc_define_test/cc_define_test.bzl): A `cc_test` that propagates a define to all its transitive dependencies. This example shows that `with_cfg.bzl` transparently supports runfiles lookups, `select`s and other features of the underlying rule.
 - [java_21_library](java_21_library/java_21_library.bzl): A `java_library` that is always built targeting Java 21, even if the default Java configuration doesn't support it.
 - [java_21_library_with_reset](java_21_library_with_reset/java_21_library.bzl): An advanced variant of `java_21_library` that uses `resettable()` to build a legacy dependency of the library with Java 7.
+- [java_test_suite_multiple_jdks](java_test_suite_multiple_jdks/test_suite.bzl): Demonstrates how to use `create_jvm_test_suite` along with `with_cfg.bzl` to run Java test suites on multiple JDK versions separately
 - [opt_filegroup](opt_filegroup/opt_filegroup.bzl): Build all files in a `filegroup` with `--compilation_mode` set to `opt`, for example to speed up an integration test using them.

--- a/examples/java_test_suite_multiple_jdks/BUILD.bazel
+++ b/examples/java_test_suite_multiple_jdks/BUILD.bazel
@@ -1,9 +1,10 @@
 load(":java_17_junit5_test.bzl", "java_17_junit5_test")
 load(":java_21_junit5_test.bzl", "java_21_junit5_test")
-load(":test_suite.bzl", "java_test_suite")
+load(":test_suite.bzl", "multi_jdk_test_suite")
 
-java_test_suite(
+multi_jdk_test_suite(
     name = "test-suite",
+    srcs = ["src/test/java/com/example/VersionTest.java"],
     test_runners = {
         "jdk21": java_21_junit5_test,
         "jdk17": java_17_junit5_test,

--- a/examples/java_test_suite_multiple_jdks/BUILD.bazel
+++ b/examples/java_test_suite_multiple_jdks/BUILD.bazel
@@ -1,4 +1,4 @@
-load("java_17_junit5_test.bzl", "java_17_junit5_test")
+load(":java_17_junit5_test.bzl", "java_17_junit5_test")
 load(":java_21_junit5_test.bzl", "java_21_junit5_test")
 load(":test_suite.bzl", "java_test_suite")
 

--- a/examples/java_test_suite_multiple_jdks/BUILD.bazel
+++ b/examples/java_test_suite_multiple_jdks/BUILD.bazel
@@ -1,0 +1,17 @@
+load("java_17_junit5_test.bzl", "java_17_junit5_test")
+load(":java_21_junit5_test.bzl", "java_21_junit5_test")
+load(":test_suite.bzl", "java_test_suite")
+
+java_test_suite(
+    name = "test-suite",
+    test_runners = {
+        "jdk21": java_21_junit5_test,
+        "jdk17": java_17_junit5_test,
+    },
+    deps = [
+        "@maven_java_test_suite_example//:org_junit_jupiter_junit_jupiter_api",
+        "@maven_java_test_suite_example//:org_junit_jupiter_junit_jupiter_engine",
+        "@maven_java_test_suite_example//:org_junit_platform_junit_platform_launcher",
+        "@maven_java_test_suite_example//:org_junit_platform_junit_platform_reporting",
+    ],
+)

--- a/examples/java_test_suite_multiple_jdks/java_17_junit5_test.bzl
+++ b/examples/java_test_suite_multiple_jdks/java_17_junit5_test.bzl
@@ -1,0 +1,6 @@
+load("@contrib_rules_jvm//java:defs.bzl", "java_junit5_test")
+load("@with_cfg.bzl", "with_cfg")
+
+_builder = with_cfg(java_junit5_test)
+_builder.set("java_language_version", "17").set("java_runtime_version", "remotejdk_17")
+java_17_junit5_test, _java_17_junit5_test_internal = _builder.build()

--- a/examples/java_test_suite_multiple_jdks/java_21_junit5_test.bzl
+++ b/examples/java_test_suite_multiple_jdks/java_21_junit5_test.bzl
@@ -1,0 +1,6 @@
+load("@contrib_rules_jvm//java:defs.bzl", "java_junit5_test")
+load("@with_cfg.bzl", "with_cfg")
+
+_builder = with_cfg(java_junit5_test)
+_builder.set("java_language_version", "21").set("java_runtime_version", "remotejdk_21")
+java_21_junit5_test, _java_21_junit5_test_internal = _builder.build()

--- a/examples/java_test_suite_multiple_jdks/src/test/java/com/example/VersionTest.java
+++ b/examples/java_test_suite_multiple_jdks/src/test/java/com/example/VersionTest.java
@@ -1,0 +1,15 @@
+package com.example;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class VersionTest {
+
+  @Test
+  public void test() {
+    List<String> properties = List.of("java.specification.version", "java.vm.vendor", "java.home");
+    for (String property : properties) {
+      System.out.printf("%s: %s\n", property, System.getProperty(property));
+    }
+  }
+}

--- a/examples/java_test_suite_multiple_jdks/src/test/java/com/example/VersionTest.java
+++ b/examples/java_test_suite_multiple_jdks/src/test/java/com/example/VersionTest.java
@@ -1,12 +1,21 @@
 package com.example;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 public class VersionTest {
 
   @Test
   public void test() {
+    // something has gone wrong if the JVM running this test is not 17 or 21, based on the
+    // configuration in BUILD.bazel
+    assertTrue(
+        Set.of("17", "21").contains(System.getProperty("java.specification.version")),
+        "expected test to only be run on JDK version 17 or 21");
+
     List<String> properties = List.of("java.specification.version", "java.vm.vendor", "java.home");
     for (String property : properties) {
       System.out.printf("%s: %s\n", property, System.getProperty(property));

--- a/examples/java_test_suite_multiple_jdks/test_suite.bzl
+++ b/examples/java_test_suite_multiple_jdks/test_suite.bzl
@@ -1,0 +1,76 @@
+load("@contrib_rules_jvm//java:defs.bzl", "create_jvm_test_suite", "java_junit5_test", "java_test")
+load("@rules_java//java:defs.bzl", "java_library")
+
+def java_test_suite(
+        name,
+        srcs = ["src/test/java/**/*.java"],
+        deps = [],
+        resources = ["src/test/resources/**/*"],
+        data = ["src/main/resources/**/*", "src/test/resources/**/*"],
+        runner = "junit5",
+        test_runners = {},
+        test_suffixes = ["Test.java"],
+        tags = []):
+    srcs = _maybe_glob(srcs)
+
+    if not srcs:
+        # no test sources found, nothing to do here
+        return
+
+    if not test_runners:
+        if runner == "junit5":
+            test_runners = {"": java_junit5_test}
+        else:
+            test_runners = {"": java_test}
+
+    def _define_library(name, **kwargs):
+        java_library(
+            name = name,
+            **kwargs
+        )
+
+    # call create_jvm_test_suite once per test runner, to allow for e.g.
+    # defining/running test targets on different JDK versions
+    for name_suffix, define_test_fn in test_runners.items():
+        # create_jvm_test_suite expects the function passed in the 'define_test'
+        # attr to return the name of the target
+
+        # normally the define_test_fn would be passed to create_jvm_test_suite
+        # directly, but we want to customize the logic: when we are creating
+        # more than 1 test suite, we need to customize the name of each
+        # individual test target to avoid reusing the same target names (which
+        # will cause a Bazel error).
+        #
+        # Being able to customize the 'define_test' function is the entire
+        # reason why we call create_jvm_test_suite() here, rather than
+        # java_test_suite().
+        def wrapped_test_fn(name, **kwargs):
+            test_name = name if name_suffix == "" else name + "-" + name_suffix
+            define_test_fn(name = test_name, **kwargs)
+            return test_name
+
+        create_jvm_test_suite(
+            name = name if name_suffix == "" else name + "-" + name_suffix,
+            srcs = _maybe_glob(srcs),
+            data = _maybe_glob(data),
+            resources = native.glob(resources),
+            runner = runner,
+            package = None,  # set to None to have rule infer package name
+            define_library = _define_library,
+            define_test = wrapped_test_fn,
+            test_suffixes = test_suffixes,
+            # java_test_suite modifies this list, so make a copy here
+            deps = [dep for dep in deps],
+            tags = tags,
+        )
+
+# handle the case where some list may be a mix of file globs and target labels
+def _maybe_glob(inputs):
+    out = []
+
+    for input in inputs:
+        if "*" in input:
+            out += native.glob([input])
+        else:
+            out.append(input)
+    return out


### PR DESCRIPTION
Inspired by a conversation on the Bazel Slack, I've converted my example of how to use `with_cfg.bzl` to run a suite of Java tests on multiple JDK versions from <https://github.com/mattnworb/bazel-java-test-suite-with_cfg-example> to an example/integration test in this repo.
