### PR TITLE
Update r_j_e in tests

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "examples"
   matrix:
-    platform: ["debian10", "macos_legacy", "ubuntu2004"]
+    platform: ["debian10", "macos", "macos_arm64", "ubuntu2004"]
     bazel: ["6.x", "7.x"]
   tasks:
     run_tests:

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(name = "rules_java", version = "7.2.0")
 bazel_dep(name = "rules_jvm_external")
 git_override(
     module_name = "rules_jvm_external",
-    commit = "0a1704520d2ef8af05613924246a18664a5ed504",
+    commit = "e4c9bf486029d027e1a26e8ba422431705a2bfce",
     remote = "https://github.com/fmeum/rules_jvm_external.git",
 )
 


### PR DESCRIPTION
This works arounds failures due to Java version detection not coping with `JAVA_TOOL_OPTIONS` messages from `java -version`.