### PR TITLE
Add a `clone()` method to builders

### DIFF
--- a/docs/defs.md
+++ b/docs/defs.md
@@ -130,4 +130,11 @@ A builder with the following methods:
       label. The rule will forward all builtin providers as well as the ones specified in
       `extra_providers` from the "exported" target after resetting the settings for it.
 
+  build() can only be called once on a builder. Subsequent calls to other methods except
+  `clone()` will fail.
+* `clone()`: Returns a new builder with the same rule and settings as the original one, but
+  acts as if `resettable()` and `reset_on_attrs()` have not been called. `set` and `extend`
+  can be called on this builder even for settings that had already been added to the original
+  builder. This is useful to create multiple rules with slightly different settings.
+
 

--- a/examples/builder_reuse/BUILD.bazel
+++ b/examples/builder_reuse/BUILD.bazel
@@ -1,0 +1,32 @@
+load(":builder.bzl", "first_cc_test", "second_cc_test")
+load(":builder_reuse.bzl", "third_cc_test")
+
+first_cc_test(
+    name = "first_cc_test",
+    srcs = ["test.cpp"],
+    env = {
+        "C_VALUE": "first",
+        "CXX_VALUE": "first",
+    },
+    visibility = ["//visibility:public"],
+)
+
+second_cc_test(
+    name = "second_cc_test",
+    srcs = ["test.cpp"],
+    env = {
+        "C_VALUE": "first",
+        "CXX_VALUE": "second",
+    },
+    visibility = ["//visibility:public"],
+)
+
+third_cc_test(
+    name = "third_cc_test",
+    srcs = ["test.cpp"],
+    env = {
+        "C_VALUE": "third",
+        "CXX_VALUE": "second",
+    },
+    visibility = ["//visibility:public"],
+)

--- a/examples/builder_reuse/builder.bzl
+++ b/examples/builder_reuse/builder.bzl
@@ -1,0 +1,28 @@
+load("@with_cfg.bzl", "with_cfg")
+
+_first_builder = with_cfg(native.cc_test)
+_first_builder.set(
+    "cxxopt",
+    select({
+        Label("@rules_cc//cc/compiler:msvc-cl"): ["/DCXX_VALUE=\"first\""],
+        "//conditions:default": ["-DCXX_VALUE=\"first\""],
+    }),
+)
+_first_builder.extend(
+    "copt",
+    select({
+        Label("@rules_cc//cc/compiler:msvc-cl"): ["/DC_VALUE=\"first\""],
+        "//conditions:default": ["-DC_VALUE=\"first\""],
+    }),
+)
+first_cc_test, _first_cc_test_ = _first_builder.build()
+
+second_builder = _first_builder
+second_builder.set(
+    "cxxopt",
+    select({
+        Label("@rules_cc//cc/compiler:msvc-cl"): ["/DCXX_VALUE=\"second\""],
+        "//conditions:default": ["-DCXX_VALUE=\"second\""],
+    }),
+)
+second_cc_test, _second_cc_test_ = second_builder.build()

--- a/examples/builder_reuse/builder.bzl
+++ b/examples/builder_reuse/builder.bzl
@@ -8,16 +8,21 @@ _first_builder.set(
         "//conditions:default": ["-DCXX_VALUE=\"first\""],
     }),
 )
+_first_builder_copt_msvc = ["/DC_VALUE=\"first\""]
+_first_builder_copt_default = ["-DC_VALUE=\"first\""]
 _first_builder.extend(
     "copt",
     select({
-        Label("@rules_cc//cc/compiler:msvc-cl"): ["/DC_VALUE=\"first\""],
-        "//conditions:default": ["-DC_VALUE=\"first\""],
+        Label("@rules_cc//cc/compiler:msvc-cl"): _first_builder_copt_msvc,
+        "//conditions:default": _first_builder_copt_default,
     }),
 )
 first_cc_test, _first_cc_test_ = _first_builder.build()
 
-second_builder = _first_builder
+second_builder = _first_builder.clone()
+
+# Demonstrate that clone() does not share mutable state with the original builder.
+_first_builder_copt_default[0] = "-DC_VALUE=\"unexpected\""
 second_builder.set(
     "cxxopt",
     select({

--- a/examples/builder_reuse/builder.bzl
+++ b/examples/builder_reuse/builder.bzl
@@ -21,8 +21,9 @@ first_cc_test, _first_cc_test_ = _first_builder.build()
 
 second_builder = _first_builder.clone()
 
-# Demonstrate that clone() does not share mutable state with the original builder.
+# Demonstrate that the builder does not capture mutable values by reference.
 _first_builder_copt_default[0] = "-DC_VALUE=\"unexpected\""
+# Demonstrate that clone() does not share mutable state with the original builder.
 second_builder.set(
     "cxxopt",
     select({

--- a/examples/builder_reuse/builder_reuse.bzl
+++ b/examples/builder_reuse/builder_reuse.bzl
@@ -1,6 +1,6 @@
 load(":builder.bzl", "second_builder")
 
-_third_builder = second_builder
+_third_builder = second_builder.clone()
 _third_builder.extend(
     "copt",
     select({

--- a/examples/builder_reuse/builder_reuse.bzl
+++ b/examples/builder_reuse/builder_reuse.bzl
@@ -1,0 +1,11 @@
+load(":builder.bzl", "second_builder")
+
+_third_builder = second_builder
+_third_builder.extend(
+    "copt",
+    select({
+        Label("@rules_cc//cc/compiler:msvc-cl"): ["/DC_VALUE=\"third\""],
+        "//conditions:default": ["-DC_VALUE=\"third\""],
+    }),
+)
+third_cc_test, _third_cc_test_ = _third_builder.build()

--- a/examples/builder_reuse/test.cpp
+++ b/examples/builder_reuse/test.cpp
@@ -1,0 +1,14 @@
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main() {
+  if (std::string(C_VALUE) != getenv("C_VALUE")) {
+    std::cerr << "C_VALUE mismatch, got: " << C_VALUE << ", want: " << getenv("C_VALUE") << std::endl;
+    return 1;
+  }
+  if (std::string(CXX_VALUE) != getenv("CXX_VALUE")) {
+    std::cerr << "CXX_VALUE mismatch, got: " << CXX_VALUE << ", want: " << getenv("CXX_VALUE") << std::endl;
+    return 1;
+  }
+}

--- a/with_cfg/private/select.bzl
+++ b/with_cfg/private/select.bzl
@@ -166,6 +166,10 @@ def consume_single_value(r, pos):
         pos += 6
         string, after_string = _consume_string(r, pos)
 
+        # On Bazel 6, stringification of Labels may not include the leading `@@`.
+        if not string.startswith("@@"):
+            string = "@" + string
+
         # Skip over `)`.
         return Label(string), after_string + 1
     elif c == "-" or c.isdigit():

--- a/with_cfg/private/with_cfg.bzl
+++ b/with_cfg/private/with_cfg.bzl
@@ -92,6 +92,13 @@ def with_cfg(
             dependencies. The reset rule has a single attribute, `exports`, which accepts a single
             label. The rule will forward all builtin providers as well as the ones specified in
             `extra_providers` from the "exported" target after resetting the settings for it.
+
+        build() can only be called once on a builder. Subsequent calls to other methods except
+        `clone()` will fail.
+      * `clone()`: Returns a new builder with the same rule and settings as the original one, but
+        acts as if `resettable()` and `reset_on_attrs()` have not been called. `set` and `extend`
+        can be called on this builder even for settings that had already been added to the original
+        builder. This is useful to create multiple rules with slightly different settings.
     """
     rule_name = get_rule_name(kind)
 


### PR DESCRIPTION
Also prevent direct and indirect modifications of already built builders.

Fixes #114 