### PR TITLE
Add prepend builder method

### DIFF
--- a/with_cfg/private/transition.bzl
+++ b/with_cfg/private/transition.bzl
@@ -49,13 +49,22 @@ def _transition_base_impl(settings, attr, *, operations, original_settings_label
             new_settings[key] = getattr(attr, attr_name)
         elif operation == "extend":
             # Ensure idempotency by appending the tail only when the list-valued setting doesn't
-            # already has the tail. This ensures that chaining transitioned rules doesn't result in
+            # already have the tail. This ensures that chaining transitioned rules doesn't result in
             # a blow-up of the list.
             tail = getattr(attr, attr_name)
             if settings[key][-len(tail):] == tail:
                 new_settings[key] = settings[key]
             else:
                 new_settings[key] = settings[key] + tail
+        elif operation == "prepend":
+            # Ensure idempotency by prepending the head only when the list-valued setting doesn't
+            # already have the head. This ensures that chaining transitioned rules doesn't result in
+            # a blow-up of the list.
+            head = getattr(attr, attr_name)
+            if settings[key][:len(head)] == head:
+                new_settings[key] = settings[key]
+            else:
+                new_settings[key] = head + settings[key]
         else:
             fail("Unknown operation: {}".format(operation))
 


### PR DESCRIPTION
Adds a new `builder.prepend` method to prepend values to a list instead of appending them, useful for things like setting defines and other order-dependent flags.

Closes #151.