### PR TITLE
Add rules_cc deps to bzl_library targets

### DIFF
--- a/with_cfg/private/BUILD.bazel
+++ b/with_cfg/private/BUILD.bazel
@@ -59,6 +59,7 @@ bzl_library(
     deps = [
         ":providers",
         "@bazel_skylib//rules:common_settings",
+        "@rules_cc//cc/common",
     ],
 )
 
@@ -97,6 +98,7 @@ bzl_library(
     srcs = ["rule_defaults.bzl"],
     visibility = ["//with_cfg:__subpackages__"],
     deps = [
+        "@rules_cc//cc/common",
         "@rules_java//java/common",
     ],
 )


### PR DESCRIPTION
This patch fixes this issue, seen when depending on with_cfg from a bzl_library target:
```
ERROR: ...: in deps attribute of starlark_doc_extract rule //:foo.extract: missing bzl_library targets for Starlark module(s) @rules_cc//cc/common:cc_info.bzl, @rules_cc//cc/common:debug_package_info.bzl. Since this rule was created by the macro 'bzl_library', the error might have been caused by the macro implementation
```