### PR TITLE
Don't use `TemplateVariableInfo` for internal purposes

### DIFF
--- a/with_cfg/private/args.bzl
+++ b/with_cfg/private/args.bzl
@@ -33,6 +33,7 @@ complexities handled by the functions in this file:
    collect the files with the given paths.
 """
 
+load(":providers.bzl", "ArgsInfo")
 load(":rewrite.bzl", "rewrite_locations_in_attr", "rewrite_locations_in_single_value")
 
 visibility("private")
@@ -109,7 +110,7 @@ def _args_aspect_impl(target, ctx):
 
     return [
         OutputGroupInfo(**{_OUTPUT_GROUPS_PREFIX + label: f for label, f in labels_to_files.items()}),
-        platform_common.TemplateVariableInfo(template_variables),
+        ArgsInfo(template_variable_info = platform_common.TemplateVariableInfo(template_variables)),
     ]
 
 args_aspect = aspect(

--- a/with_cfg/private/providers.bzl
+++ b/with_cfg/private/providers.bzl
@@ -14,6 +14,10 @@ RuleInfo = provider(fields = [
     "test",
 ])
 
+ArgsInfo = provider(fields = [
+    "template_variable_info",
+])
+
 FrontendInfo = provider(fields = [
     "executable",
     "providers",

--- a/with_cfg/private/transitioning_alias.bzl
+++ b/with_cfg/private/transitioning_alias.bzl
@@ -1,5 +1,5 @@
 load(":args.bzl", "args_aspect")
-load(":providers.bzl", "FrontendInfo", "OriginalSettingsInfo")
+load(":providers.bzl", "ArgsInfo", "FrontendInfo", "OriginalSettingsInfo")
 load(":setting.bzl", "get_attr_type", "validate_and_get_attr_name")
 
 visibility("private")
@@ -70,7 +70,7 @@ def _transitioning_alias_base_impl(ctx, *, providers):
             executable = target[DefaultInfo].files_to_run.executable,
             providers = providers,
             run_environment_info = target[RunEnvironmentInfo] if RunEnvironmentInfo in target else None,
-            template_variable_info = target[platform_common.TemplateVariableInfo] if platform_common.TemplateVariableInfo in target else None,
+            template_variable_info = target[ArgsInfo].template_variable_info if ArgsInfo in target else None,
         ))
 
     return returned_providers


### PR DESCRIPTION
9b510242163b6eab0c0cee706a53e4d4986ddabb resulted in duplicate provider errors when a rule naturally returns this provider.