### PR TITLE
chore: maven_export repro

### DIFF
--- a/examples/java_21_library/BUILD.bazel
+++ b/examples/java_21_library/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_jvm_external//:defs.bzl", "maven_export")
 load(":java_21_library.bzl", "java_21_library")
 
 java_binary(
@@ -24,4 +25,10 @@ java_21_library(
 alias(
     name = "primes_sources",
     actual = "libprimes-src.jar",
+)
+
+maven_export(
+    name = "primes-export",
+    maven_coordinates = "foo:bar:0.0.1",
+    lib_name = "primes",
 )

--- a/examples/java_21_library/BUILD.bazel
+++ b/examples/java_21_library/BUILD.bazel
@@ -8,10 +8,13 @@ java_binary(
     deps = [":primes"],
 )
 
+_COORDINATES = "foo:bar:0.0.1"
+
 java_21_library(
     name = "primes",
     srcs = ["src/main/java/com/example/Primes.java"],
     deps = [":integer_type"],
+    tags = ["maven_coordinates=" + _COORDINATES],
 )
 
 java_21_library(
@@ -29,6 +32,6 @@ alias(
 
 maven_export(
     name = "primes-export",
-    maven_coordinates = "foo:bar:0.0.1",
+    maven_coordinates = _COORDINATES,
     lib_name = "primes",
 )


### PR DESCRIPTION
This PR illustrates `maven_export` fails to create a jar.

```shell
$ bazel build //java_21_library:primes-export
...
$ file bazel-bin/java_21_library/primes-export-project.jar
bazel-bin/java_21_library/primes-export-project.jar: Zip archive data (empty)
```

It seems RJE gets confused the chain of deps and exports so https://github.com/bazel-contrib/rules_jvm_external/blob/7a7d0383e585cbbab5d69dce65b0d90ee84ce3ed/private/rules/has_maven_deps.bzl#L113 produces exactly the sets of jars.

I have a feeling it is related to how RJE interprets `maven_coordinates=` tag. IIUC, all the targets created by with_cfg have tags propagated, and that might make RJE wrongly believe some target is the "target" while it is not: https://github.com/bazel-contrib/rules_jvm_external/blob/7a7d0383e585cbbab5d69dce65b0d90ee84ce3ed/private/rules/maven_project_jar.bzl#L193-L197